### PR TITLE
Fix segment-fault when pipe

### DIFF
--- a/ipv6calc/ipv6calc.c
+++ b/ipv6calc/ipv6calc.c
@@ -884,7 +884,7 @@ PIPE_input:
 		DEBUGPRINT_WA(DEBUG_ipv6calc_general, "Token 1: '%s'", input1);
 
 		/* check for second token */
-		if (*ptrptr[0] != '\0') {
+		if (ptrptr && ptrptr[0] && *ptrptr[0] != '\0') {
 			input2 = *ptrptr;
 			inputc = 2;
 


### PR DESCRIPTION
* Platform
```
uname -a
Darwin MacBook-Pro.local 18.2.0 Darwin Kernel Version 18.2.0: Mon Nov 12 20:24:46 PST 2018; root:xnu-4903.231.4~2/RELEASE_X86_64 x86_64
```

* Problem:
```
echo 2600:1400:: | ./ipv6calc --printfulluncompressed -f
Segmentation fault: 11 (core dumped)
```

* Call stack:
```
(lldb) bt all
* thread #1, stop reason = signal SIGSTOP
  * frame #0: 0x000000010577cfec ipv6calc`main(argc=<unavailable>, argv=<unavailable>) at ipv6calc.c:887 [opt]
    frame #1: 0x00007fff65a9ced9 libdyld.dylib`start + 1
    frame #2: 0x00007fff65a9ced9 libdyld.dylib`start + 1
```

* After fix:
```
echo 2600:1400:: | ./ipv6calc --printfulluncompressed -f
2600:1400:0000:0000:0000:0000:0000:0000
```