### PR TITLE
Fix incorrect use of XOR

### DIFF
--- a/databases/lib/libipv6calc_db_wrapper.c
+++ b/databases/lib/libipv6calc_db_wrapper.c
@@ -3642,7 +3642,7 @@ int libipv6calc_db_asn_filter_parse(s_ipv6calc_filter_db_asn *filter, const char
 		asn = (uint32_t) strtol(token + offset, NULL, 10);
 
 		if (errno == ERANGE) {
-			ERRORPRINT_WA("filter token 'asn=' requires a valid decimal number between 0 and %ul: %s:", (2^32) - 1, token + offset);
+			ERRORPRINT_WA("filter token 'asn=' requires a valid decimal number between 0 and %ul: %s:", (1UL << 32) - 1, token + offset);
 			goto END_ipv6calc_db_asn_filter_parse;
 		};
 	};


### PR DESCRIPTION
`2^32` is `34` not `4294967296`, and its type is `int` not `unsigned long` as
needed by the `"%ul"` specifier.

I'm not sure why it does just say `"between 0 and 4294967295"` though.