### PR TITLE
add support for compressed IPv4 addresses, like 10/8

### DIFF
--- a/ipv6calc/test_ipv6calc.sh
+++ b/ipv6calc/test_ipv6calc.sh
@@ -91,6 +91,7 @@ cat <<END | grep -v '^#'
 --addr_to_uncompressed --maskprefix 3ffe:ffff:100:f101::1/64		=3ffe:ffff:100:f101:0:0:0:0/64
 --addr_to_uncompressed --masksuffix 3ffe:ffff:100:f101:c000::1/64	=0:0:0:0:c000:0:0:1/64
 --addr_to_uncompressed --uppercase ::ffff:13.1.68.3			=0:0:0:0:0:FFFF:13.1.68.3
+--out ipv4addr --no-prefixlength 1.2.3.4				=1.2.3.4
 --out ipv4addr --no-prefixlength 1.2.3.4/24				=1.2.3.4
 --out ipv4addr --no-prefixlength 1.2.3/24				=1.2.3.0
 --out ipv4addr --no-prefixlength 1.2/24					=1.2.0.0
@@ -266,6 +267,15 @@ cat <<END | grep -v '^#'
 2.2.3.4/-1									ipv4addr
 2.2.3.4/33									ipv4addr
 1.2.3.4/									ipv4addr
+1										ipv4addr
+1.										ipv4addr
+1.2										ipv4addr
+1.2.										ipv4addr
+1.2.3										ipv4addr
+1.2.3.										ipv4addr
+1.2.3.4.									ipv4addr
+1.2.3.4.5									ipv4addr
+1.2.3.4.5/10									ipv4addr
 /10										ipv4addr
 ./10										ipv4addr
 01:23:r5:67:89:01								mac

--- a/ipv6calc/test_ipv6calc.sh
+++ b/ipv6calc/test_ipv6calc.sh
@@ -96,6 +96,9 @@ cat <<END | grep -v '^#'
 --out ipv4addr --no-prefixlength 1.2.3/24				=1.2.3.0
 --out ipv4addr --no-prefixlength 1.2/24					=1.2.0.0
 --out ipv4addr --no-prefixlength 1/24					=1.0.0.0
+--out ipv4addr 1.2.3.4/0						=1.2.3.4/0
+--out ipv4addr 0/0							=0.0.0.0/0
+--out ipv4addr --printcompressed 0/0					=0/0
 --out ipv4addr --printcompressed 1.2.3.4/24				=1.2.3.4/24
 --out ipv4addr --printcompressed 1.2.3.0/24				=1.2.3/24
 --out ipv4addr --printcompressed 1.2.3/24				=1.2.3/24
@@ -267,6 +270,8 @@ cat <<END | grep -v '^#'
 2.2.3.4/-1									ipv4addr
 2.2.3.4/33									ipv4addr
 1.2.3.4/									ipv4addr
+1.2.3.4/00									ipv4addr
+0/00										ipv4addr
 1										ipv4addr
 1.										ipv4addr
 1.2										ipv4addr

--- a/ipv6calc/test_ipv6calc.sh
+++ b/ipv6calc/test_ipv6calc.sh
@@ -92,7 +92,20 @@ cat <<END | grep -v '^#'
 --addr_to_uncompressed --masksuffix 3ffe:ffff:100:f101:c000::1/64	=0:0:0:0:c000:0:0:1/64
 --addr_to_uncompressed --uppercase ::ffff:13.1.68.3			=0:0:0:0:0:FFFF:13.1.68.3
 --out ipv4addr --no-prefixlength 1.2.3.4/24				=1.2.3.4
+--out ipv4addr --no-prefixlength 1.2.3/24				=1.2.3.0
+--out ipv4addr --no-prefixlength 1.2/24					=1.2.0.0
+--out ipv4addr --no-prefixlength 1/24					=1.0.0.0
+--out ipv4addr --printcompressed 1.2.3.4/24				=1.2.3.4/24
+--out ipv4addr --printcompressed 1.2.3.0/24				=1.2.3/24
+--out ipv4addr --printcompressed 1.2.3/24				=1.2.3/24
+--out ipv4addr --printcompressed 1.2.0.0/24				=1.2/24
+--out ipv4addr --printcompressed 1.2/24					=1.2/24
+--out ipv4addr --printcompressed 1.0.0.0/24				=1/24
+--out ipv4addr --printcompressed 1/24					=1/24
 --out ipv4addr --maskprefix 1.2.3.4/24					=1.2.3.0/24
+--out ipv4addr --maskprefix 1.2.3./24					=1.2.3.0/24
+--out ipv4addr --maskprefix 1.2./24					=1.2.0.0/24
+--out ipv4addr --maskprefix 1./24					=1.0.0.0/24
 --out ipv4addr --masksuffix 1.2.3.4/24					=0.0.0.4/24
 --out ipv4addr --maskprefix 1.2.3.4/22					=1.2.0.0/22
 --out ipv4addr --masksuffix 1.2.3.4/22 					=0.0.3.4/22
@@ -252,6 +265,7 @@ cat <<END | grep -v '^#'
 1.2.3.r4									ipv4addr
 2.2.3.4/-1									ipv4addr
 2.2.3.4/33									ipv4addr
+1.2.3.4/									ipv4addr
 01:23:r5:67:89:01								mac
 2002:102:304::r1								ipv6addr
 2002:102:304::1/-1								ipv6addr

--- a/ipv6calc/test_ipv6calc.sh
+++ b/ipv6calc/test_ipv6calc.sh
@@ -266,6 +266,8 @@ cat <<END | grep -v '^#'
 2.2.3.4/-1									ipv4addr
 2.2.3.4/33									ipv4addr
 1.2.3.4/									ipv4addr
+/10										ipv4addr
+./10										ipv4addr
 01:23:r5:67:89:01								mac
 2002:102:304::r1								ipv6addr
 2002:102:304::1/-1								ipv6addr

--- a/lib/ipv6calchelp.c
+++ b/lib/ipv6calchelp.c
@@ -523,7 +523,13 @@ static void printhelp_output_ifinet6void(void) {
 };
 
 static void printhelp_output_ipv4addr(void) {
-	fprintf(stderr, " Print an IPv4 address\n");
+	fprintf(stderr, " Print an IPv4 address, depending on format options:\n");
+	fprintf(stderr, "  Uncompressed, e.g.\n");
+	fprintf(stderr, "   1.2.0.0 -> 1.2.0.0\n");
+	fprintf(stderr, "   1.2.0.  -> 1.2.0.0\n");
+	fprintf(stderr, "   1.2     -> 1.2.0.0\n");
+	fprintf(stderr, "  Compressed, e.g.\n");
+	fprintf(stderr, "   1.2.0.0 -> 1.2\n");
 };
 
 static void printhelp_output_revipv4(void) {

--- a/lib/ipv6calctypes.h
+++ b/lib/ipv6calctypes.h
@@ -253,7 +253,7 @@ typedef struct {
 	{ FORMAT_eui64          , FORMATOPTION_printlowercase | FORMATOPTION_printuppercase },
 	{ FORMAT_base85         , 0 },
 	{ FORMAT_ifinet6        , 0 },
-	{ FORMAT_ipv4addr       , FORMATOPTION_machinereadable | FORMATOPTION_no_prefixlength | FORMATOPTION_forceprefix | FORMATOPTION_maskprefix | FORMATOPTION_masksuffix },
+	{ FORMAT_ipv4addr       , FORMATOPTION_machinereadable | FORMATOPTION_no_prefixlength | FORMATOPTION_forceprefix | FORMATOPTION_maskprefix | FORMATOPTION_masksuffix | FORMATOPTION_printcompressed | FORMATOPTION_printuncompressed | FORMATOPTION_printfulluncompressed },
 	{ FORMAT_iid_token      , FORMATOPTION_printlowercase | FORMATOPTION_printuppercase },
 	{ FORMAT_octal          , FORMATOPTION_printfulluncompressed },
 	{ FORMAT_ipv6literal    , FORMATOPTION_machinereadable | FORMATOPTION_printlowercase | FORMATOPTION_printuppercase | FORMATOPTION_printcompressed | FORMATOPTION_printuncompressed | FORMATOPTION_printfulluncompressed },

--- a/lib/libipv4addr.c
+++ b/lib/libipv4addr.c
@@ -456,6 +456,11 @@ int addr_to_ipv4addrstruct(const char *addrstring, char *resultstring, const siz
 	{
 		if (*p >= '0' && *p <= '9') {
 			digit = 1;
+			if (in_prefix_len && p[0] == '0' && p[1] && compat[i] == 0) {
+				snprintf(resultstring, resultstring_length, "Error in given IPv4 address, '%s' is not valid (CIDR prefix length cannot start with zero)!",
+			                 addrstring);
+				return (1);
+			}
 			compat[i] = compat[i] * 10 + (*p - '0');
 			if (compat[i] > (in_prefix_len ? 32 : 255)) {
 				snprintf(resultstring, resultstring_length, "Error in given IPv4 address, '%s' is not valid (%d on position %d)!",

--- a/lib/libipv4addr.c
+++ b/lib/libipv4addr.c
@@ -441,7 +441,8 @@ int addr_to_ipv4addrstruct(const char *addrstring, char *resultstring, const siz
 	uint32_t typeinfo;
 	const char *p;
 
-	resultstring[0] = '\0'; /* clear result string */
+	if (resultstring_length > 0)
+		resultstring[0] = '\0'; /* clear result string */
 
 	DEBUGPRINT_WA(DEBUG_libipv4addr, "Got input '%s'",  addrstring);
 

--- a/lib/libipv4addr.c
+++ b/lib/libipv4addr.c
@@ -464,7 +464,7 @@ int addr_to_ipv4addrstruct(const char *addrstring, char *resultstring, const siz
 		} else if (*p == '.' && !in_prefix_len && digit) {
 			digit = 0;
 			i++;
-		} else if (*p == '/' && !in_prefix_len) {
+		} else if (*p == '/' && !in_prefix_len && p != addrstring) {
 			digit = 0;
 			in_prefix_len = 1;
 			i = 4;

--- a/lib/libipv4addr.c
+++ b/lib/libipv4addr.c
@@ -485,6 +485,16 @@ int addr_to_ipv4addrstruct(const char *addrstring, char *resultstring, const siz
 		return (1);
 	}
 
+	/* do not allow '1.2', but allow '1.2/12' */
+	if (!in_prefix_len && i < 3) {
+		snprintf(resultstring, resultstring_length, "Error in given IPv4 address, '%s' is not valid (missing %d dots)!", addrstring, 3-i);
+		return (1);
+	}
+	if (!in_prefix_len && p[-1] == '.') {
+		snprintf(resultstring, resultstring_length, "Error in given IPv4 address, '%s' is not valid (missing last octet)!", addrstring);
+		return (1);
+	}
+
 	ipv4addr_clearall(ipv4addrp);
 	if (in_prefix_len) {
 		ipv4addrp->flag_prefixuse = 1;

--- a/lib/libipv6calc.c
+++ b/lib/libipv6calc.c
@@ -140,6 +140,7 @@ uint32_t libipv6calc_autodetectinput(const char *string) {
 	unsigned int numdots = 0, numcolons = 0, numdigits = 0, numxdigits = 0, numdashes = 0, numspaces = 0, numslashes = 0, numalnums = 0, numchar_s = 0, numpercents = 0, numcolonsdouble = 0, xdigitlen_max = 0, xdigitlen_min = 0, xdl;
 	char resultstring[NI_MAXHOST];
 	size_t length;
+	ipv6calc_ipv4addr ipv4addr;
 
 	length = strlen(string);
 
@@ -147,6 +148,12 @@ uint32_t libipv6calc_autodetectinput(const char *string) {
 		/* input is empty */
 		goto END_libipv6calc_autodetectinput;
 	};
+
+	ipv4addr_clearall(&ipv4addr);
+	if (addr_to_ipv4addrstruct(string, NULL, 0, &ipv4addr) == 0) {
+		type = FORMAT_ipv4addr;
+		goto END_libipv6calc_autodetectinput;
+	}
 
 	xdl = 0;
 	for (i = 0; i < (int) length; i++) {
@@ -213,20 +220,6 @@ uint32_t libipv6calc_autodetectinput(const char *string) {
 			type = FORMAT_base85;
 			goto END_libipv6calc_autodetectinput;
 		} else DEBUGPRINT_WA(DEBUG_libipv6calc, " check FORMAT_base85 not successful, result: %s", resultstring);
-	};
-	
-	if (numcolons == 0 && numdigits == numxdigits && numslashes <= 1 && (numdots + numdigits + numslashes) == length) {
-		unsigned int a3 = numslashes ? 3 : 0;
-		unsigned int a2 = numslashes ? 2 : 0;
-		unsigned int a1 = numslashes ? 1 : 0;
-		if (   (numdots == 3 && length >= 6+a2 && length <= 15+a3 && numdigits >= 3+a1 && numdigits <= 12+a2)
-		    || (numdots == 2 && length >= 4+a2 && length <= 11+a3 && numdigits >= 2+a1 && numdigits <=  9+a2)
-		    || (numdots == 1 && length >= 2+a2 && length <=  7+a3 && numdigits >= 1+a1 && numdigits <=  6+a2)
-		    || (numdots == 0 && length >= 1+a2 && length <=  4+a3 && numdigits >= 1+a1 && numdigits <=  3+a2)) {
-			/* IPv4: d{1-3}(.d{1-3})?(.d{1-3})?(.d{0-3})?(/d{1-2})? */
-			type = FORMAT_ipv4addr;
-			goto END_libipv6calc_autodetectinput;
-		}
 	};
 
 	if ( strncmp(string, "\\[", 2) == 0 ) {

--- a/lib/libipv6calc.c
+++ b/lib/libipv6calc.c
@@ -215,12 +215,18 @@ uint32_t libipv6calc_autodetectinput(const char *string) {
 		} else DEBUGPRINT_WA(DEBUG_libipv6calc, " check FORMAT_base85 not successful, result: %s", resultstring);
 	};
 	
-	if (((length >= 7 && length <= 15 && numdots == 3 && numcolons == 0 && numdigits == numxdigits && numdigits >= 4 && numdigits <= 12 && numslashes == 0 )
-	    || ((length >= 9 && length <= 18 && numdots == 3 && numcolons == 0 && numdigits == numxdigits && numdigits >= 5 && numdigits <= 14 && numslashes == 1)))
-	    && (numdots + numdigits + numslashes) == length) {
-		/* IPv4: d{1-3}.d{1-3}.d{1-3}.d{1-3} or d{1-3}.d{1-3}.d{1-3}.d{1-3}/d{1-2} */
-		type = FORMAT_ipv4addr;
-		goto END_libipv6calc_autodetectinput;
+	if (numcolons == 0 && numdigits == numxdigits && numslashes <= 1 && (numdots + numdigits + numslashes) == length) {
+		unsigned int a3 = numslashes ? 3 : 0;
+		unsigned int a2 = numslashes ? 2 : 0;
+		unsigned int a1 = numslashes ? 1 : 0;
+		if (   (numdots == 3 && length >= 6+a2 && length <= 15+a3 && numdigits >= 3+a1 && numdigits <= 12+a2)
+		    || (numdots == 2 && length >= 4+a2 && length <= 11+a3 && numdigits >= 2+a1 && numdigits <=  9+a2)
+		    || (numdots == 1 && length >= 2+a2 && length <=  7+a3 && numdigits >= 1+a1 && numdigits <=  6+a2)
+		    || (numdots == 0 && length >= 1+a2 && length <=  4+a3 && numdigits >= 1+a1 && numdigits <=  3+a2)) {
+			/* IPv4: d{1-3}(.d{1-3})?(.d{1-3})?(.d{0-3})?(/d{1-2})? */
+			type = FORMAT_ipv4addr;
+			goto END_libipv6calc_autodetectinput;
+		}
 	};
 
 	if ( strncmp(string, "\\[", 2) == 0 ) {


### PR DESCRIPTION
This allows the IPv4 addresses with CIDR prefix to be specified and displayed in compressed form, for example:

```
address       uncompressed      compressed
1.2.3.4/12 -> 1.2.3.4/12     -> 1.2.3.4/12
1.2.3./12  -> 1.2.3.0/12     -> 1.2.3/12
1.2.3/12   -> 1.2.3.0/12     -> 1.2.3/12
10/8       -> 10.0.0.0/8     -> 10/8
```

This involved full rewrite of IPv4 parser using some sort of finite state machine, making code more simple and compact.