### PR TITLE
Fix tests on OpenBSD

### DIFF
--- a/ipv6calcweb/create_ipv6calcweb-cgi.sh
+++ b/ipv6calcweb/create_ipv6calcweb-cgi.sh
@@ -36,8 +36,8 @@ perl -pi -e "s/\@PACKAGE_VERSION\@/$v/" ipv6calcweb.cgi || exit 1
 perl -pi -e "s/\@COPYRIGHT_YEAR\@/$c/" ipv6calcweb.cgi || exit 1
 
 case "$OSTYPE" in
-    freebsd*)
-	# FreeBSD has somehow issue with -T, so remove it
+    freebsd*|openbsd*)
+	# *BSD has somehow issue with -T, so remove it
 	perl -pi -e "s/perl -w -T/perl -w/" ipv6calcweb.cgi || exit 1
 	;;
 esac

--- a/ipv6logstats/test_ipv6logstats.sh
+++ b/ipv6logstats/test_ipv6logstats.sh
@@ -223,14 +223,14 @@ testscenarios_match | while read ip match; do
 	fi
 
 	if $verbose; then
-		echo "$ip" | ./ipv6logstats -q | grep -q "$match\W*1"
+		echo "$ip" | ./ipv6logstats -q | grep -xq "$match[^_[:alnum:]]*1"
 		result=$?
 	else
-		echo "$ip" | ./ipv6logstats -q 2>/dev/null | grep -q "$match\W*1"
+		echo "$ip" | ./ipv6logstats -q 2>/dev/null | grep -xq "$match[^_[:alnum:]]*1"
 		result=$?
 	fi
 	if [ $result -ne 0 ]; then
-		echo "ERROR: unexpected result calling echo $ip | ./ipv6logstats -q | grep -q $match\W*1':"
+		echo "ERROR: unexpected result calling echo $ip | ./ipv6logstats -q | grep -xq '$match[^_[:alnum:]]*1':"
 		echo "$ip" | ./ipv6logstats -q | grep -v "DB-Info"
 		exit 1
 	fi


### PR DESCRIPTION
1. Apply same `perl -T` option removing hack for OpenBSD like it was done for FreeBSD

2. Use portable `[^_[:alnum:]]` instead of `\W` GNUism in grep calls

I also added `-x` option to grep(1) calls while there, since we for sure do not want to match some extra garbage.

`make test` now succeeds on OpenBSD, hurray!