### PR TITLE
IP2LOCATION_API_VERSION could be defined in IP2Location.h now

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1185,16 +1185,6 @@ if test "$IP2LOCATION" = "yes"; then
 				AC_MSG_ERROR([IP2Location has only compat IPv6 support (API < 7.0.0) or old (API < 8.2.0) which is no longer supported])
 			]
 		)
-
-		AC_CHECK_DECLS([USAGETYPE],
-			[
-				AC_MSG_RESULT([IP2Location has full support (library >= 6.0.0)])
-			],
-			[
-				AC_MSG_ERROR([IP2Location library header file misses USAGETYPE (library < 6.0.0) which is no longer supported])
-			]
-		)
-
 	],
 	[
 		AC_MSG_ERROR([IP2Location library header files not found])
@@ -1212,8 +1202,6 @@ if test "$IP2LOCATION" = "yes"; then
 
 		if test -n "$IP2LOCATION_LIB_DIR"; then
 			if test -e "$IP2LOCATION_LIB_DIR/lib$IP2LOCATION_LIB_NAME.so"; then
-				LDFLAGS="$LDFLAGS -L$IP2LOCATION_LIB_DIR"
-				CFLAGS="$CFLAGS -L$IP2LOCATION_LIB_DIR"
 				LIBS="-L$IP2LOCATION_LIB_DIR"
 			else
 				AC_MSG_ERROR([IP2Location library file not found: $IP2LOCATION_INCLUDE_DIR/lib$IP2LOCATION_LIB_NAME.so])

--- a/databases/lib/libipv6calc_db_wrapper.c
+++ b/databases/lib/libipv6calc_db_wrapper.c
@@ -52,15 +52,6 @@ static int uint64_log2(uint64_t n) {
 #define uint64_log2	log2
 #endif
 
-#ifdef SUPPORT_IP2LOCATION
-/*
- * API_VERSION is defined as a bareword in IP2Location.h,
- * we need this trick to stringify it. Blah.
- */
-#define makestr(x) #x
-#define xmakestr(x) makestr(x)
-#endif
-
 #ifdef SUPPORT_GEOIP2
 static int wrapper_GeoIP2_disable      = 0;
 static int wrapper_GeoIP2_status = 0;
@@ -673,7 +664,7 @@ void libipv6calc_db_wrapper_print_features_verbose(const int level_verbose) {
 #ifdef IP2LOCATION_INCLUDE_VERSION
 		fprintf(stderr, "IP2Location support enabled, compiled with include file version: %s\n", IP2LOCATION_INCLUDE_VERSION);
 #endif
-		fprintf(stderr, "IP2Location support enabled, compiled with API version: %s, dynamically linked with version: %s\n", xmakestr(API_VERSION), libipv6calc_db_wrapper_IP2Location_lib_version());
+		fprintf(stderr, "IP2Location support enabled, compiled with API version: %s, dynamically linked with version: %s\n", IP2LOCATION_API_VERSION, libipv6calc_db_wrapper_IP2Location_lib_version());
 #ifndef SUPPORT_IP2LOCATION_DYN
 #else
 		fprintf(stderr, "IP2Location support by dynamic library load\n");

--- a/databases/lib/libipv6calc_db_wrapper_IP2Location.c
+++ b/databases/lib/libipv6calc_db_wrapper_IP2Location.c
@@ -431,15 +431,6 @@ static const s_type2 libipv6calc_db_wrapper_IP2Location_UsageType[] = {
 };
 
 
-/* 
- * API_VERSION is defined as a bareword in IP2Location.h, 
- *  we need this trick to stringify it. Blah.
- */
-#define makestr(x) #x
-#define xmakestr(x) makestr(x)
-
-#define IP2LOCATION_API_VERSION	xmakestr(API_VERSION)
-
 #ifdef SUPPORT_IP2LOCATION_DYN
 char ip2location_lib_file[PATH_MAX] = IP2LOCATION_DYN_LIB;
 

--- a/databases/lib/libipv6calc_db_wrapper_IP2Location.h
+++ b/databases/lib/libipv6calc_db_wrapper_IP2Location.h
@@ -247,4 +247,15 @@ extern int ip2location_db_only_type;
 extern int ip2location_db_allow_softlinks;
 
 extern int          libipv6calc_db_wrapper_IP2Location_all_by_addr(const ipv6calc_ipaddr *ipaddrp, libipv6calc_db_wrapper_geolocation_record *recordp);
+
+#ifndef IP2LOCATION_API_VERSION
+/*
+ * API_VERSION in old versions was defined as a bareword in IP2Location.h,
+ *  we need this trick to stringify it. Blah.
+ */
+#define makestr(x) #x
+#define xmakestr(x) makestr(x)
+#define IP2LOCATION_API_VERSION xmakestr(API_VERSION)
+#endif /* IP2LOCATION_API_VERSION */
+
 #endif


### PR DESCRIPTION
With https://github.com/chrislim2888/IP2Location-C-Library/pull/62 merged, IP2LOCATION_API_VERSION is defined in IP2Location.h, no need to define it in wrappers.