### PR TITLE
Add missing prefix definition

### DIFF
--- a/tools/Makefile.in
+++ b/tools/Makefile.in
@@ -6,6 +6,7 @@
 #  Makefile for various tools
 #
 
+prefix          = @prefix@
 datadir         = @datadir@
 
 all:


### PR DESCRIPTION
prefix was removed in 456599bfb1462972435956601caee39d136aab13. Without this fix, it will end up installing tools to /share since @datadir@ is expanded to ${prefix}/share.